### PR TITLE
Add support for TLS 1.3 decryption

### DIFF
--- a/Wireshark/plugins/v2gtlssecret.lua
+++ b/Wireshark/plugins/v2gtlssecret.lua
@@ -78,6 +78,10 @@ function p_v2gtlssecret.dissector(buf,pinfo,root)
         ::continue::
     end
 
+    if #tls_secret_list == 0 then
+        return 0
+    end
+
     -- set info column
     pinfo.cols.info = "TLS disclosure message for " .. table.concat(info_strings, ", ")
 

--- a/Wireshark/plugins/v2gtlssecret.lua
+++ b/Wireshark/plugins/v2gtlssecret.lua
@@ -55,7 +55,7 @@ function p_v2gtlssecret.dissector(buf,pinfo,root)
     -- one UDP packet may contain several lines, check each line
     for line in str:gmatch'[^\r\n]+' do
         -- check if this is really a secret
-        match = line:match'^([%u_]+)%d* %x+ %x+$'
+        local match = line:match'^([%u_]+)%d* %x+ %x+$'
         if match == nil then
             goto continue
         elseif match == "CLIENT_RANDOM" then
@@ -116,14 +116,10 @@ function p_v2gtlssecret.dissector(buf,pinfo,root)
         if file ~= nil then
             for line in file:lines() do
                 local tls_secret_of_file = tostring(line)
-                local idx_to_delete = {}
-                for idx, tls_secret in ipairs(tls_secret_list) do
-                    if tls_secret == tls_secret_of_file then
-                        table.insert(idx_to_delete, idx)
+                for idx = #tls_secret_list, 1, -1 do
+                    if tls_secret_list[idx] == tls_secret_of_file then
+                        table.remove(tls_secret_list, idx)
                     end
-                end
-                for _, idx in ipairs(idx_to_delete) do
-                    table.remove(tls_secret_list, idx)
                 end
                 if #tls_secret_list == 0 then
                     break


### PR DESCRIPTION
Add support for TLS 1.3 disclosure messages. A UDP secret disclosure message can contain one secret or multiple secrets separated by a line break.

Fixes #2 