### PR TITLE
Fix for incorrectly labelled disclosure packets

### DIFF
--- a/Wireshark/plugins/v2gtlssecret.lua
+++ b/Wireshark/plugins/v2gtlssecret.lua
@@ -79,8 +79,8 @@ function p_v2gtlssecret.dissector(buf,pinfo,root)
             table.insert(tls_secret_list, line)
             subtree:add(f_cr,buf(byte_offset, line:len()))
         end
-        byte_offset = byte_offset + line:len() + 1
         ::continue::
+        byte_offset = byte_offset + line:len() + 1
     end
 
     if #tls_secret_list == 0 then


### PR DESCRIPTION
Since #4, all UDP packets in port range of v2gtlssecrets have been labelled as v2gtlssecrets, regardless of their content.