### PR TITLE
Fix for incorrectly labelled disclosure packets

### DIFF
--- a/Installer/InstallerScript.iss
+++ b/Installer/InstallerScript.iss
@@ -1,5 +1,5 @@
 // DO NOT CHANGE VERSION HERE! Run update_version.bat
-#define AppVer "1.2.0"
+#define AppVer "1.3.0"
 #define AppId "dsV2Gshark"
 
 [Setup]

--- a/OSSAcknowledgements.txt
+++ b/OSSAcknowledgements.txt
@@ -141,7 +141,7 @@ cbExiGen
 
 The license text of the 'Apache License Version 2.0' can be found in APPENDIX A.
 
-Wireshark 4.2.3
+Wireshark 4.2.4
   Copyright:
     Copyright 1998-2024 Gerald Combs <gerald@wireshark.org> and contributors
   Repository: https://gitlab.com/wireshark/wireshark

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The plugin processes a TLS master secret disclosure packet after handshake to de
 The disclosure message is a UDP packet within the source port range 49152-65535 (see Wireshark protocol settings) containing the ASCII string `CLIENT_RANDOM <32-byte client random> <48-byte master secret>` as payload data. This disclosure message has to be sent from one of the communication partners in a testing environment.  
 For TLS 1.3 decryption you have to provide different secrets: `CLIENT_HANDSHAKE_TRAFFIC_SECRET`, `SERVER_HANDSHAKE_TRAFFIC_SECRET`, `EXPORTER_SECRET`, `CLIENT_TRAFFIC_SECRET_<number>`, `SERVER_TRAFFIC_SECRET_<number>`. You can send one UDP packet for each secret or combine the secrets in one UDP packet (separated by line breaks).
 
+
 ### Wireshark I/O Graph
 This optional feature updates the Wireshark I/O Graph preferences to display a V2G session. The graph can be accessed via 'Statistics' -> 'I/O Graphs' (shortcut: Alt + S + I).  
 The graph displays the data in 1 second intervals. This can be changed using the drop down menu at the bottom.  
@@ -57,10 +58,11 @@ Click on a packet in the graph to inspect it in the Wireshark main window. Press
 
 ## Limitations
 - ISO 15118-20 is not fully supported yet
-    - some BPT messages are not fully decoded
+    - please let us know if you encounter incorrectly decoded packets
 - Linux
     - no installer
     - filter buttons and color filters must be added manually
+    - I/O graph must be configured manually
 
 ## Support
 - If you encounter any problems, feel free to open an issue or contact us at support@dSPACE.de
@@ -69,7 +71,7 @@ Click on a packet in the graph to inspect it in the Wireshark main window. Press
 ## Further notes
 - When sniffing V2G communication, lost packets may occur, which cause corrupted TCP/TLS sessions. In that case, it may help to activate the option to ignore Message Authentication Code (MAC) check failures in the Wireshark TLS protocol settings.  
     This option can be found under Wireshark Preferences - Protocols - TLS
-- This plugin was built and tested with Wireshark 4.2.3
+- This plugin was built and tested with Wireshark 4.2.4
 - The EXI decoding is based on [cbExiGen](https://github.com/EVerest/cbexigen)
 
 

--- a/V2G_Libraries/CertificateInfos/main.rc
+++ b/V2G_Libraries/CertificateInfos/main.rc
@@ -1,11 +1,11 @@
 #include <windows.h>
 
-#define VER_FILEVERSION             1,2,0,0
-#define VER_FILEVERSION_STR         "1.2.0.0\0"
+#define VER_FILEVERSION             1,3,0,0
+#define VER_FILEVERSION_STR         "1.3.0.0\0"
 #define VER_COMPANYNAME_STR         "dSPACE GmbH"
 #define VER_PRODUCTNAME_STR         "V2gCertificateInfos"
-#define VER_PRODUCTVERSION          1,2,0,0
-#define VER_PRODUCTVERSION_STR      "1.2.0.0\0"
+#define VER_PRODUCTVERSION          1,3,0,0
+#define VER_PRODUCTVERSION_STR      "1.3.0.0\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION VER_FILEVERSION

--- a/V2G_Libraries/V2GDecoder/main.rc
+++ b/V2G_Libraries/V2GDecoder/main.rc
@@ -1,11 +1,11 @@
 #include <windows.h>
 
-#define VER_FILEVERSION             1,2,0,0
-#define VER_FILEVERSION_STR         "1.2.0.0\0"
+#define VER_FILEVERSION             1,3,0,0
+#define VER_FILEVERSION_STR         "1.3.0.0\0"
 #define VER_COMPANYNAME_STR         "dSPACE GmbH"
 #define VER_PRODUCTNAME_STR         "V2gDecoder"
-#define VER_PRODUCTVERSION          1,2,0,0
-#define VER_PRODUCTVERSION_STR      "1.2.0.0\0"
+#define VER_PRODUCTVERSION          1,3,0,0
+#define VER_PRODUCTVERSION_STR      "1.3.0.0\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION VER_FILEVERSION

--- a/Wireshark/plugins/v2gmsg.lua
+++ b/Wireshark/plugins/v2gmsg.lua
@@ -10,7 +10,7 @@
 --
 -- See license file (dsV2Gshark_LICENSE.txt)
 --
-DS_V2GSHARK_VERSION = "1.2.0" -- DO NOT CHANGE
+DS_V2GSHARK_VERSION = "1.3.0" -- DO NOT CHANGE
 
 p_v2gmsg = Proto("v2gmsg", "V2G Message")
 local p_v2gmsg_info = {

--- a/Wireshark/plugins/v2gsdp.lua
+++ b/Wireshark/plugins/v2gsdp.lua
@@ -5,111 +5,109 @@
 -- See license file (dsV2Gshark_LICENSE.txt)
 --
 
-p_sdpreq = Proto("v2gsdp-req","V2G SECC Discovery Protocol Request")
-p_sdpres = Proto("v2gsdp-res","V2G SECC Discovery Protocol Response")
+p_sdpreq = Proto("v2gsdp-req", "V2G SECC Discovery Protocol Request")
+p_sdpres = Proto("v2gsdp-res", "V2G SECC Discovery Protocol Response")
 local p_v2gsdp_info = {
     version = DS_V2GSHARK_VERSION,
-    author = "dSPACE GmbH",
+    author = "dSPACE GmbH"
 }
 set_plugin_info(p_v2gsdp_info)
 
-
 -- V2G SDP Request
-local f_req_sec = ProtoField.uint8("v2gsdp-req.security","Security",base.HEX)
-local f_req_tp  = ProtoField.uint8("v2gsdp-req.transportprotocol","Transport Protocol",base.HEX)
+local f_req_sec = ProtoField.uint8("v2gsdp-req.security", "Security", base.HEX)
+local f_req_tp = ProtoField.uint8("v2gsdp-req.transportprotocol", "Transport Protocol", base.HEX)
 local f_req_emsp_ids = ProtoField.string("v2gsdp-req.emsp", "EMSP IDs")
 
 local WITH_TLS = 0
 local NO_TLS = 16
 
 local sec_types = {
-    [WITH_TLS]  = "Secured with TLS",              -- 0x00
-    [NO_TLS]    = "No transport layer security",   -- 0x10
+    [WITH_TLS] = "Secured with TLS", -- 0x00
+    [NO_TLS] = "No transport layer security" -- 0x10
 }
 
-p_sdpreq.fields = {f_req_sec,f_req_tp,f_req_emsp_ids}
+p_sdpreq.fields = {f_req_sec, f_req_tp, f_req_emsp_ids}
 
 -- SDP Request dissection function
-function p_sdpreq.dissector(buf,pinfo,root)
+function p_sdpreq.dissector(buf, pinfo, root)
     pinfo.cols.protocol = "V2GMSG (SDP)"
 
     -- create subtree
-    subtree = root:add(p_sdpreq,buf(0))
+    subtree = root:add(p_sdpreq, buf(0))
 
     -- add protocol fields to subtree
 
     local emsp = pinfo.private["SDP_ESMP"]
     if emsp ~= nil and emsp == true then
+        -- else: emsp list is empty
         -- Note: the SDP_RES_EMSP misses the fields 'Security' and 'Transport Protocol',
         -- since EMPS is only useful with PnC (TCP + TLS)
         if buf:len() > 0 then
-		    subtree:add(f_req_emsp_ids, buf(0))
+            subtree:add(f_req_emsp_ids, buf(0))
         end
-        -- else: emsp list is empty
     else
         -- Security
-        local sec_num = buf(0,1):uint()
-        local sec = subtree:add(f_req_sec,buf(0,1))
+        local sec_num = buf(0, 1):uint()
+        local sec = subtree:add(f_req_sec, buf(0, 1))
         if sec_types[sec_num] ~= nil then
-            sec:append_text(" (" .. sec_types[sec_num] ..")")
+            sec:append_text(" (" .. sec_types[sec_num] .. ")")
             -- Concatenate the info of v2g
             pinfo.cols.info = tostring(pinfo.cols.info) .. ", " .. sec_types[sec_num]
         end
 
         -- Transport Protocol
-        local tp = subtree:add(f_req_tp,buf(1,1))
-        if buf(1,1):uint() == 0 then
+        local tp = subtree:add(f_req_tp, buf(1, 1))
+        if buf(1, 1):uint() == 0 then
             tp:append_text(" (TCP)")
         end
     end
 end
 
 -- V2G SDP Response
-local f_res_ipv6   = ProtoField.ipv6("v2gsdp-res.ipv6","SECC IP Address")
-local f_res_port = ProtoField.uint16("v2gsdp-res.port","SECC Port")
-local f_res_sec = ProtoField.uint8("v2gsdp-res.security","Security",base.HEX)
-local f_res_tp  = ProtoField.uint8("v2gsdp-res.transportprotocol","Transport Protocol",base.HEX)
+local f_res_ipv6 = ProtoField.ipv6("v2gsdp-res.ipv6", "SECC IP Address")
+local f_res_port = ProtoField.uint16("v2gsdp-res.port", "SECC Port")
+local f_res_sec = ProtoField.uint8("v2gsdp-res.security", "Security", base.HEX)
+local f_res_tp = ProtoField.uint8("v2gsdp-res.transportprotocol", "Transport Protocol", base.HEX)
 local f_res_emsp_ids = ProtoField.string("v2gsdp-res.emsp", "EMSP IDs")
 
-p_sdpres.fields = {f_res_ipv6,f_res_port,f_res_sec,f_res_tp,f_res_emsp_ids}
+p_sdpres.fields = {f_res_ipv6, f_res_port, f_res_sec, f_res_tp, f_res_emsp_ids}
 
 -- SDP Response dissection function
-function p_sdpres.dissector(buf,pinfo,root)
+function p_sdpres.dissector(buf, pinfo, root)
     pinfo.cols.protocol = "V2GMSG (SDP)"
 
     -- create subtree
-    local subtree = root:add(p_sdpres,buf(0))
+    local subtree = root:add(p_sdpres, buf(0))
 
     -- add protocol fields to subtree
     -- SECC IPv6
-    subtree:add(f_res_ipv6,buf(0,16))
+    subtree:add(f_res_ipv6, buf(0, 16))
     -- SECC Port
-    subtree:add(f_res_port,buf(16,2))
-
+    subtree:add(f_res_port, buf(16, 2))
 
     local emsp = pinfo.private["SDP_ESMP"]
     if emsp ~= nil and emsp == true and buf:len() > 18 then
         -- Note: the SDP_RES_EMSP misses the fields 'Security' and 'Transport Protocol',
         -- since EMPS is only useful with PnC (TCP + TLS)
-		subtree:add(f_req_emsp_ids, buf(18))
+        subtree:add(f_req_emsp_ids, buf(18))
     else
         -- Security
-        local sec_num = buf(18,1):uint()
-        local sec = subtree:add(f_res_sec,buf(18,1))
+        local sec_num = buf(18, 1):uint()
+        local sec = subtree:add(f_res_sec, buf(18, 1))
         if sec_types[sec_num] ~= nil then
-            sec:append_text(" (" .. sec_types[sec_num] ..")")
+            sec:append_text(" (" .. sec_types[sec_num] .. ")")
             -- Concatenate the info of v2g
             pinfo.cols.info = tostring(pinfo.cols.info) .. ", " .. sec_types[sec_num]
         end
 
         -- Transport Protocol
-        local tp = subtree:add(f_res_tp,buf(19,1))
-        if buf(19,1):uint() == 0 then
+        local tp = subtree:add(f_res_tp, buf(19, 1))
+        if buf(19, 1):uint() == 0 then
             tp:append_text(" (TCP)")
             if sec_num == NO_TLS then
-                DissectorTable.get("tcp.port"):add(buf(16,2):uint(),Dissector.get("v2gtp"))
+                DissectorTable.get("tcp.port"):add(buf(16, 2):uint(), Dissector.get("v2gtp"))
             elseif sec_num == WITH_TLS then
-                DissectorTable.get("tls.port"):add(buf(16,2):uint(),Dissector.get("v2gtp"))
+                DissectorTable.get("tls.port"):add(buf(16, 2):uint(), Dissector.get("v2gtp"))
             end
         end
     end

--- a/Wireshark/plugins/v2gtlssecret.lua
+++ b/Wireshark/plugins/v2gtlssecret.lua
@@ -145,7 +145,7 @@ function p_v2gtlssecret.dissector(buf,pinfo,root)
                             if splitted_from_file[3] == splitted_from_packet[3] then
                                 to_be_removed = true
                             else
-                                add_expert_info("CLIENT RANDOM is not unique!", subtree, pinfo, ef_io_error)
+                                add_expert_info("CLIENT RANDOM part of secret is not unique! (\"" .. splitted_from_packet[2] .. "\")" , subtree, pinfo, ef_io_error)
                             end
                         end
                     end

--- a/Wireshark/plugins/v2gtlssecret.lua
+++ b/Wireshark/plugins/v2gtlssecret.lua
@@ -57,7 +57,7 @@ function p_v2gtlssecret.dissector(buf,pinfo,root)
         -- check if this is really a secret
         local match = line:match'^([%u_]+)%d* %x+ %x+$'
         if match == nil then
-            goto continue
+            return 0
         elseif match == "CLIENT_RANDOM" then
             table.insert(info_strings, "master secret")
         elseif match == "CLIENT_HANDSHAKE_TRAFFIC_SECRET" then
@@ -75,7 +75,6 @@ function p_v2gtlssecret.dissector(buf,pinfo,root)
         if line:len() > 100 and line:len() < 300 then
             table.insert(tls_secret_list, line)
         end
-        ::continue::
     end
 
     if #tls_secret_list == 0 then

--- a/Wireshark/plugins/v2gtlssecret.lua
+++ b/Wireshark/plugins/v2gtlssecret.lua
@@ -6,7 +6,7 @@
 -- See license file (dsV2Gshark_LICENSE.txt)
 --
 
-p_v2gtlssecret = Proto("v2gtlssecret","V2G TLS secret")
+p_v2gtlssecret = Proto("v2gtlssecret", "V2G TLS secret")
 local p_v2gtlssecret_info = {
     version = DS_V2GSHARK_VERSION,
     author = "dSPACE GmbH"
@@ -15,10 +15,18 @@ set_plugin_info(p_v2gtlssecret_info)
 
 local min_wireshark_version = "3.5.0"
 
-local f_cr  = ProtoField.string("v2gtlssecret.clientrandom","NSS Key Log",base.ASCII)
+local f_cr = ProtoField.string("v2gtlssecret.clientrandom", "NSS Key Log", base.ASCII)
 
-local ef_io_error = ProtoExpert.new("tls_secret", "Failed to open keylog-file!", expert.group.DECRYPTION, expert.severity.WARN)
-local ef_bad_version = ProtoExpert.new("tls_secret", "To use the TLS disclosure message to decrypt the application data Wireshark/Tshark version " .. tostring(min_wireshark_version) .. " or higher is required.", expert.group.DECRYPTION, expert.severity.WARN)
+local ef_io_error =
+    ProtoExpert.new("tls_secret", "Failed to open keylog-file!", expert.group.DECRYPTION, expert.severity.WARN)
+local ef_bad_version =
+    ProtoExpert.new(
+    "tls_secret",
+    "To use the TLS disclosure message to decrypt the application data Wireshark/Tshark version " ..
+        tostring(min_wireshark_version) .. " or higher is required.",
+    expert.group.DECRYPTION,
+    expert.severity.WARN
+)
 
 local tmpDir = os.getenv("TEMP")
 if tmpDir == nil then
@@ -31,15 +39,17 @@ local frame_numbers = {} -- save the numbers of the frames including TLS secrets
 p_v2gtlssecret.fields = {f_cr}
 p_v2gtlssecret.experts = {ef_io_error, ef_bad_version}
 
-
 -- verify tshark/wireshark version is compatible
 local function check_version(required_version)
     major_req, minor_req, micro_req = required_version:match("(%d+)%.(%d+)%.(%d+)")
     major, minor, micro = get_version():match("(%d+)%.(%d+)%.(%d+)")
 
-    if (tonumber(major) < tonumber(major_req)) or
-         ((tonumber(major) == tonumber(major_req)) and (tonumber(minor) < tonumber(minor_req))) or
-         ((tonumber(major) == tonumber(major_req)) and (tonumber(minor) == tonumber(minor_req)) and (tonumber(micro) < tonumber(micro_req))) then
+    if
+        (tonumber(major) < tonumber(major_req)) or
+            ((tonumber(major) == tonumber(major_req)) and (tonumber(minor) < tonumber(minor_req))) or
+            ((tonumber(major) == tonumber(major_req)) and (tonumber(minor) == tonumber(minor_req)) and
+                (tonumber(micro) < tonumber(micro_req)))
+     then
         return false
     else
         return true
@@ -48,30 +58,30 @@ end
 
 local function split_string(str)
     local parts = {}
-    for part in str:gmatch'[^ \r\n]+' do
+    for part in str:gmatch "[^ \r\n]+" do
         table.insert(parts, part)
     end
     return parts
 end
 
 local function add_expert_info(message, tree, pinfo, expertinfo)
-	local oldInfo = tostring(pinfo.cols.info)
+    local oldInfo = tostring(pinfo.cols.info)
     if string.len(oldInfo) < 9 or oldInfo:sub(0, 9) ~= "[WARNING]" then
-		tree:add_proto_expert_info(expertinfo, message)
+        tree:add_proto_expert_info(expertinfo, message)
         pinfo.cols.info = "[WARNING] " .. oldInfo
     end
 end
 
 -- PDU dissection function
-function p_v2gtlssecret.dissector(buf,pinfo,root)
+function p_v2gtlssecret.dissector(buf, pinfo, root)
     local str = buf:raw()
     local tls_secret_list = {}
     local info_strings = {}
-    
+
     -- one UDP packet may contain several lines, check each line
-    for line in str:gmatch'[^\r\n]+' do
+    for line in str:gmatch "[^\r\n]+" do
         -- check if this is really a secret
-        local match = line:match'^([%u_]+)%d* %x+ %x+$'
+        local match = line:match "^([%u_]+)%d* %x+ %x+$"
         if match == nil then
             return 0
         elseif match == "CLIENT_RANDOM" then
@@ -98,9 +108,9 @@ function p_v2gtlssecret.dissector(buf,pinfo,root)
     end
 
     local byte_offset = 0
-    local subtree = root:add(p_v2gtlssecret,buf(byte_offset))
+    local subtree = root:add(p_v2gtlssecret, buf(byte_offset))
     for _, v in ipairs(tls_secret_list) do
-        subtree:add(f_cr,buf(byte_offset, v:len()))
+        subtree:add(f_cr, buf(byte_offset, v:len()))
         byte_offset = byte_offset + v:len() + 1 -- (+1) for line break
     end
 
@@ -121,7 +131,7 @@ function p_v2gtlssecret.dissector(buf,pinfo,root)
 
     -- write TLS secret only once and restart dissector once
     local already_visited = false
-    for _,v in ipairs(frame_numbers) do
+    for _, v in ipairs(frame_numbers) do
         if v == pinfo.number then
             already_visited = true
         end
@@ -134,18 +144,26 @@ function p_v2gtlssecret.dissector(buf,pinfo,root)
         if file ~= nil then
             local file_content = file:read("*a")
             file:close(file)
-    
+
             for idx = #tls_secret_list, 1, -1 do
                 local to_be_removed = false
                 local splitted_from_packet = split_string(tls_secret_list[idx])
-                for line in file_content:gmatch'[^\r\n]+' do    
+                for line in file_content:gmatch "[^\r\n]+" do
                     local splitted_from_file = split_string(tostring(line))
                     if #splitted_from_packet == 3 and #splitted_from_file == 3 then
-                        if splitted_from_file[1] == splitted_from_packet[1] and splitted_from_file[2] == splitted_from_packet[2] then
+                        if
+                            splitted_from_file[1] == splitted_from_packet[1] and
+                                splitted_from_file[2] == splitted_from_packet[2]
+                         then
                             if splitted_from_file[3] == splitted_from_packet[3] then
                                 to_be_removed = true
                             else
-                                add_expert_info("CLIENT RANDOM part of secret is not unique! (\"" .. splitted_from_packet[2] .. "\")" , subtree, pinfo, ef_io_error)
+                                add_expert_info(
+                                    'CLIENT RANDOM part of secret is not unique! ("' .. splitted_from_packet[2] .. '")',
+                                    subtree,
+                                    pinfo,
+                                    ef_io_error
+                                )
                             end
                         end
                     end
@@ -156,7 +174,6 @@ function p_v2gtlssecret.dissector(buf,pinfo,root)
                 if #tls_secret_list == 0 then
                     break
                 end
-
             end
         end
 

--- a/Wireshark/plugins/v2gtp.lua
+++ b/Wireshark/plugins/v2gtp.lua
@@ -5,68 +5,67 @@
 -- See license file (dsV2Gshark_LICENSE.txt)
 --
 
-p_v2gtp = Proto("v2gtp","V2G Transfer Protocol")
+p_v2gtp = Proto("v2gtp", "V2G Transfer Protocol")
 local p_v2gtp_info = {
     version = DS_V2GSHARK_VERSION,
-    author = "dSPACE GmbH",
+    author = "dSPACE GmbH"
 }
 set_plugin_info(p_v2gtp_info)
 
 local V2GTP_HDR_LENGTH = 8
 
-local f_pv  = ProtoField.uint8("v2gtp.protoversion","Protocol Version",base.HEX)
-local f_ipv = ProtoField.uint8("v2gtp.inverseprotoversion","Inverse Protocol Version",base.HEX)
-local f_pt  = ProtoField.uint16("v2gtp.payloadtype","Payload Type",base.HEX)
-local f_len = ProtoField.uint32("v2gtp.length","Payload Length",base.DEC)
+local f_pv = ProtoField.uint8("v2gtp.protoversion", "Protocol Version", base.HEX)
+local f_ipv = ProtoField.uint8("v2gtp.inverseprotoversion", "Inverse Protocol Version", base.HEX)
+local f_pt = ProtoField.uint16("v2gtp.payloadtype", "Payload Type", base.HEX)
+local f_len = ProtoField.uint32("v2gtp.length", "Payload Length", base.DEC)
 
-local V2G      = 32769
+local V2G = 32769
 local I20_MAIN = 32770
-local I20_AC   = 32771
-local I20_DC   = 32772
+local I20_AC = 32771
+local I20_DC = 32772
 local I20_ACDP = 32773
-local I20_WPT  = 32774
+local I20_WPT = 32774
 -- 32775 - 33024 reserved
-local I20_SCHEDULE_RENEG  = 33025 -- Note: not tested yet. ISO-20 support is expirimental in this version!
-local I20_METER_CONF      = 33026 -- Note: not tested yet. ISO-20 support is expirimental in this version!
+local I20_SCHEDULE_RENEG = 33025 -- Note: not tested yet. ISO-20 support is expirimental in this version!
+local I20_METER_CONF = 33026 -- Note: not tested yet. ISO-20 support is expirimental in this version!
 local I20_ACDP_SYS_STATUS = 33027 -- Note: not tested yet. ISO-20 support is expirimental in this version!
-local I20_PARKING_STATUS  = 33028 -- Note: not tested yet. ISO-20 support is expirimental in this version!
+local I20_PARKING_STATUS = 33028 -- Note: not tested yet. ISO-20 support is expirimental in this version!
 -- 33029 - 36863 reserved
-local SDP_REQ  = 36864
-local SDP_RES  = 36865
-local SDP_REQ_W  = 36866
-local SDP_RES_W  = 36867
-local SDP_REQ_EMSP  = 36868
-local SDP_RES_EMSP  = 36869
+local SDP_REQ = 36864
+local SDP_RES = 36865
+local SDP_REQ_W = 36866
+local SDP_RES_W = 36867
+local SDP_REQ_EMSP = 36868
+local SDP_RES_EMSP = 36869
 
 local payload_types = {
-    [V2G]                   = "ISO 15118-2/DIN/SAP",  -- 0x8001
-    [I20_MAIN]              = "ISO 15118-20 Main Stream",
-    [I20_AC]                = "ISO 15118-20 Main AC",
-    [I20_DC]                = "ISO 15118-20 Main DC",
-    [I20_ACDP]              = "ISO 15118-20 ACDP",
-    [I20_WPT]               = "ISO 15118-20 WPT",
-    [I20_SCHEDULE_RENEG]    = "ISO 15118-20 Schedule Renegotiation", -- 0x8101
-    [I20_METER_CONF]        = "ISO 15118-20 Metering Confirmation",
-    [I20_ACDP_SYS_STATUS]   = "ISO 15118-20 ACDP System Status",
-    [I20_PARKING_STATUS]    = "ISO 15118-20 Parking Status",
-    [SDP_REQ]               = "SDP request message",      -- 0x9000
-    [SDP_RES]               = "SDP response message",     -- 0x9001
-    [SDP_REQ_W]             = "SDP request message Wireless (Not supported yet)",
-    [SDP_RES_W]             = "SDP response message Wireless (Not supported yet)",
-    [SDP_REQ_EMSP]          = "SDP EMSP request message",
-    [SDP_RES_EMSP]          = "SDP EMSP response message",
+    [V2G] = "ISO 15118-2/DIN/SAP", -- 0x8001
+    [I20_MAIN] = "ISO 15118-20 Main Stream",
+    [I20_AC] = "ISO 15118-20 Main AC",
+    [I20_DC] = "ISO 15118-20 Main DC",
+    [I20_ACDP] = "ISO 15118-20 ACDP",
+    [I20_WPT] = "ISO 15118-20 WPT",
+    [I20_SCHEDULE_RENEG] = "ISO 15118-20 Schedule Renegotiation", -- 0x8101
+    [I20_METER_CONF] = "ISO 15118-20 Metering Confirmation",
+    [I20_ACDP_SYS_STATUS] = "ISO 15118-20 ACDP System Status",
+    [I20_PARKING_STATUS] = "ISO 15118-20 Parking Status",
+    [SDP_REQ] = "SDP request message", -- 0x9000
+    [SDP_RES] = "SDP response message", -- 0x9001
+    [SDP_REQ_W] = "SDP request message Wireless (Not supported yet)",
+    [SDP_RES_W] = "SDP response message Wireless (Not supported yet)",
+    [SDP_REQ_EMSP] = "SDP EMSP request message",
+    [SDP_RES_EMSP] = "SDP EMSP response message"
 }
 
-
-p_v2gtp.fields = {f_pv,f_ipv,f_pt,f_len}
+p_v2gtp.fields = {f_pv, f_ipv, f_pt, f_len}
 
 -- PDU dissection function
-local function v2gtp_pdu_dissect(buf,pinfo,root)
-    if tostring(buf(0,2)) ~= "01fe" then
+local function v2gtp_pdu_dissect(buf, pinfo, root)
+    if tostring(buf(0, 2)) ~= "01fe" then
         return 0
     end
 
-    local p_type_num = buf(2,2):uint()
+    local p_type_num = buf(2, 2):uint()
     local prev_proto = tostring(pinfo.cols.protocol)
 
     pinfo.cols.protocol = "V2G TP"
@@ -78,19 +77,19 @@ local function v2gtp_pdu_dissect(buf,pinfo,root)
 
     -- create subtree
     --
-    local subtree = root:add(p_v2gtp,buf(0))
+    local subtree = root:add(p_v2gtp, buf(0))
 
     -- add protocol fields to subtree
 
     -- Protocol Version
-    subtree:add(f_pv,buf(0,1))
+    subtree:add(f_pv, buf(0, 1))
     -- Inverse Protocol Version
-    subtree:add(f_ipv,buf(1,1))
+    subtree:add(f_ipv, buf(1, 1))
 
     -- Payload type
-    local p_type = subtree:add(f_pt,buf(2,2))
+    local p_type = subtree:add(f_pt, buf(2, 2))
     if payload_types[p_type_num] ~= nil then
-        p_type:append_text(" (" .. payload_types[p_type_num] ..")")
+        p_type:append_text(" (" .. payload_types[p_type_num] .. ")")
         -- Concatenate the info of v2g
         if tostring(pinfo.cols.info) ~= "" then
             pinfo.cols.info = tostring(pinfo.cols.info) .. ", " .. payload_types[p_type_num]
@@ -102,7 +101,7 @@ local function v2gtp_pdu_dissect(buf,pinfo,root)
     end
 
     -- Length
-    subtree:add(f_len, buf(4,4))
+    subtree:add(f_len, buf(4, 4))
 
     -- EMSP
     if p_type_num == SDP_REQ_EMSP or p_type_num == SDP_RES_EMSP then
@@ -115,52 +114,52 @@ local function v2gtp_pdu_dissect(buf,pinfo,root)
     --
     if buf:len() > V2GTP_HDR_LENGTH then
         if p_type_num == SDP_REQ then
-            Dissector.get("v2gsdp-req"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gsdp-req"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         elseif p_type_num == SDP_RES then
-            Dissector.get("v2gsdp-res"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gsdp-res"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         elseif p_type_num == V2G then
             -- do not set schema for 8001 payloads, s.t. it is derived from the SAP
-            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         elseif p_type_num == I20_MAIN then
             pinfo.private["Schema"] = "urn:iso:std:iso:15118:-20:CommonMessages"
-            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         elseif p_type_num == I20_AC then
             pinfo.private["Schema"] = "urn:iso:std:iso:15118:-20:AC"
-            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         elseif p_type_num == I20_DC then
             pinfo.private["Schema"] = "urn:iso:std:iso:15118:-20:DC"
-            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         elseif p_type_num == I20_ACDP then
             pinfo.private["Schema"] = "urn:iso:std:iso:15118:-20:ACDP"
-            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         elseif p_type_num == I20_WPT then
             pinfo.private["Schema"] = "urn:iso:std:iso:15118:-20:WPT"
-            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         elseif p_type_num == I20_SCHEDULE_RENEG then
             -- the schema must be derived from the SAP in this case. TODO: test this as soon as sidestreams are used
-            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         elseif p_type_num == I20_METER_CONF then
             pinfo.private["Schema"] = "urn:iso:std:iso:15118:-20:CommonMessages" -- Meter Conf Sidestream uses common messages only
-            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         elseif p_type_num == I20_ACDP_SYS_STATUS then
             pinfo.private["Schema"] = "urn:iso:std:iso:15118:-20:ACDP"
-            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         elseif p_type_num == I20_PARKING_STATUS then
             pinfo.private["Schema"] = "urn:iso:std:iso:15118:-20:CommonMessages"
-            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(),pinfo,root)
+            Dissector.get("v2gmsg"):call(buf(V2GTP_HDR_LENGTH):tvb(), pinfo, root)
         end
     end
 end
 
 -- main dissection function
-function p_v2gtp.dissector(buf,pinfo,root)
-    return v2gtp_pdu_dissect(buf,pinfo,root)
+function p_v2gtp.dissector(buf, pinfo, root)
+    return v2gtp_pdu_dissect(buf, pinfo, root)
 end
 
 -- initialization routine
 function p_v2gtp.init()
     -- register protocol
-    DissectorTable.get("udp.port"):add(15118,p_v2gtp)
-    DissectorTable.get("tcp.port"):add(15118,p_v2gtp)
-    DissectorTable.get("tls.port"):add(15118,p_v2gtp)
+    DissectorTable.get("udp.port"):add(15118, p_v2gtp)
+    DissectorTable.get("tcp.port"):add(15118, p_v2gtp)
+    DissectorTable.get("tls.port"):add(15118, p_v2gtp)
 end


### PR DESCRIPTION
Since https://github.com/dspace-group/dsV2Gshark/pull/4, all UDP packets in port range of v2gtlssecrets have been labelled as v2gtlssecrets, regardless of their content.