### PR TITLE
Add FLAGS option to fix build on Linux

### DIFF
--- a/V2G_Libraries/Third_Party/cbv2g/makefile
+++ b/V2G_Libraries/Third_Party/cbv2g/makefile
@@ -10,7 +10,7 @@ OBJECTS = $(patsubst %.c,$(OBJ_DIR)/%.o,$(SOURCE))
 DEPS = $(patsubst %.h,$(OBJ_DIR)/%.d,$(HEADER))
 INCLUDES = $(wildcard */.)
 LFLAGS = $(foreach d, $(INCLUDES), -I"$(d)") -MP -MD
-FLAGS = -c -Wall -O3
+FLAGS = -c -Wall -O3 -fPIC
 
 build: $(OBJECTS)
 


### PR DESCRIPTION
The test build was done on Linux Fedora 39.

The curent build status:

/usr/bin/ld: ../Third_Party/cbv2g/obj/appHandshake/appHand_Decoder.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value

To fix the build issue add '-fPIC' to FLAGS variable.

FLAGS = -c -Wall -O3 -fPIC