### PR TITLE
Add support for lua 5.1

### DIFF
--- a/V2G_Libraries/CertificateInfos/makefile_linux
+++ b/V2G_Libraries/CertificateInfos/makefile_linux
@@ -17,7 +17,8 @@ BINARY=$(BINARY_DIR_OUT)/$(BINARY_FILE)
 FLAGS_COMMON = -Wall -O3 -MP -MD -fPIC
 FLAGS_LIB	 = -shared -static-libstdc++ -static-libgcc 
 
-IFLAGS = -I"../Third_Party/lua/lua-5.2.4/include" -I"../Third_Party/GnuTLS/include"
+LUAFLAGS ?= -I"../Third_Party/lua/lua-5.2.4/include"
+IFLAGS =  ${LUAFLAGS} -I"../Third_Party/GnuTLS/include"
 
 dll: $(BINARY)
 

--- a/V2G_Libraries/CertificateInfos/src/LuaLib_Cert.cpp
+++ b/V2G_Libraries/CertificateInfos/src/LuaLib_Cert.cpp
@@ -62,7 +62,11 @@ extern "C"
                 // function name, function reference
                 {"getX509Infos", l_getX509Infos},
                 {NULL, NULL}};
+#if LUA_VERSION_NUM > 501
         luaL_newlib(L, X509CertInfos);
+#else
+        luaL_register(L, "X509CertInfos", X509CertInfos);
+#endif
         return 1;
     }
 }

--- a/V2G_Libraries/V2GDecoder/makefile_linux
+++ b/V2G_Libraries/V2GDecoder/makefile_linux
@@ -17,7 +17,8 @@ BINARY=$(BINARY_DIR_OUT)/$(BINARY_FILE)
 FLAGS_COMMON = -Wall -O3 -MP -MD -fPIC
 FLAGS_LIB	 = -shared -static-libstdc++ -static-libgcc
 
-IFLAGS = -I"../Third_Party/lua/lua-5.2.4/include" -I"../Third_Party/zlib/include" -I"../Third_Party/libxml2/include/libxml2"
+LUAFLAGS ?= -I"../Third_Party/lua/lua-5.2.4/include"
+IFLAGS = ${LUAFLAGS} -I"../Third_Party/zlib/include" -I"../Third_Party/libxml2/include/libxml2"
 
 # CBV2G
 PATH_CBV2G = ../Third_Party/cbv2g

--- a/V2G_Libraries/V2GDecoder/src/LuaLib_V2G.cpp
+++ b/V2G_Libraries/V2GDecoder/src/LuaLib_V2G.cpp
@@ -149,7 +149,11 @@ extern "C"
                 {"initValidator", l_validate_init},
                 {"cleanupValidator", l_validate_cleanup},
                 {NULL, NULL}};
+#if LUA_VERSION_NUM > 501
         luaL_newlib(L, LuaDecoderLib);
+#else
+        luaL_register(L, "LuaDecoder", LuaDecoderLib);
+#endif
         return 1;
     }
 }


### PR DESCRIPTION
Some OS as openSUSE (until version 15.5) or Fedora (until version 39) build Wireshark with lua version 5.1. So we don't want to use the lua embedded third party (version 5.2) to build the *.so files, because the lua version will not match the lua version embedded in Wireshark.

This commit do not break and change the current build workflow.

To use an alternative lua version install the lua devel package and execute:

export LUAFLAGS="-I$(pkg-config --variable=includedir lua51)" cd V2G_Libraries
./build_all_linux.sh