### PR TITLE
Fix for homeplug-av packets (SLAC) on old wireshark versions

### DIFF
--- a/Installer/InstallerScript.iss
+++ b/Installer/InstallerScript.iss
@@ -260,9 +260,12 @@ begin
                     '"TRUE","[V2G ext]","v2gtp or v2gtlssecret or tls.handshake or tls.alert_message or tcp.flags.syn == 1 or tcp.flags.fin == 1 or homeplug or homeplug-av ",""',
                     '"TRUE","[V2G]","v2gtp or v2gtlssecret",""',
 
-                    // current buttons
+                    // v1.4.0 buttons
                     '"TRUE","[V2G ext]","v2gtp or v2gtlssecret or tls.handshake or tls.alert_message or tls.change_cipher_spec or tcp.flags.syn == 1 or tcp.flags.fin == 1 or homeplug or homeplug-av ","Filter V2G messages, SLAC messages and additional TCP packets"',
-                    '"TRUE","[V2G]","v2gtp or v2gtlssecret","Filter V2G messages"'];
+
+                    // current buttons
+                    '"TRUE","[V2G]","v2gtp or v2gtlssecret","Filter V2G messages"',
+                    '"TRUE","[V2G ext]","v2gtp or v2gtlssecret or tls.handshake or tls.alert_message or tls.change_cipher_spec or tcp.flags.syn == 1 or tcp.flags.fin == 1 or homeplug or homeplug-av or homeplug-llc ","Filter V2G messages, SLAC messages and additional TCP packets"'];
   RemoveFromFile(FileName, LinesToRemove);
 
   FileName := GetWiresharkConfigPath + 'io_graphs'
@@ -283,7 +286,7 @@ begin
     if WizardIsComponentSelected('buttons') then
     begin
       FileName := GetWiresharkConfigPath + 'dfilter_buttons'
-      StringsToCheck := ['"TRUE","[V2G ext]","v2gtp or v2gtlssecret or tls.handshake or tls.alert_message or tls.change_cipher_spec or tcp.flags.syn == 1 or tcp.flags.fin == 1 or homeplug or homeplug-av ","Filter V2G messages, SLAC messages and additional TCP packets"',
+      StringsToCheck := ['"TRUE","[V2G ext]","v2gtp or v2gtlssecret or tls.handshake or tls.alert_message or tls.change_cipher_spec or tcp.flags.syn == 1 or tcp.flags.fin == 1 or homeplug or homeplug-av or homeplug-llc ","Filter V2G messages, SLAC messages and additional TCP packets"',
                          '"TRUE","[V2G]","v2gtp or v2gtlssecret","Filter V2G messages"']
       StringsToAdd := CheckLines(FileName, StringsToCheck)
       if Length(StringsToAdd) > 0 then

--- a/Installer/InstallerScript.iss
+++ b/Installer/InstallerScript.iss
@@ -1,5 +1,5 @@
 // DO NOT CHANGE VERSION HERE! Run update_version.bat
-#define AppVer "1.4.0"
+#define AppVer "1.4.1"
 #define AppId "dsV2Gshark"
 
 [Setup]

--- a/V2G_Libraries/CertificateInfos/main.rc
+++ b/V2G_Libraries/CertificateInfos/main.rc
@@ -1,11 +1,11 @@
 #include <windows.h>
 
-#define VER_FILEVERSION             1,4,0,0
-#define VER_FILEVERSION_STR         "1.4.0.0\0"
+#define VER_FILEVERSION             1,4,1,0
+#define VER_FILEVERSION_STR         "1.4.1.0\0"
 #define VER_COMPANYNAME_STR         "dSPACE GmbH"
 #define VER_PRODUCTNAME_STR         "V2gCertificateInfos"
-#define VER_PRODUCTVERSION          1,4,0,0
-#define VER_PRODUCTVERSION_STR      "1.4.0.0\0"
+#define VER_PRODUCTVERSION          1,4,1,0
+#define VER_PRODUCTVERSION_STR      "1.4.1.0\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION VER_FILEVERSION

--- a/V2G_Libraries/V2GDecoder/main.rc
+++ b/V2G_Libraries/V2GDecoder/main.rc
@@ -1,11 +1,11 @@
 #include <windows.h>
 
-#define VER_FILEVERSION             1,4,0,0
-#define VER_FILEVERSION_STR         "1.4.0.0\0"
+#define VER_FILEVERSION             1,4,1,0
+#define VER_FILEVERSION_STR         "1.4.1.0\0"
 #define VER_COMPANYNAME_STR         "dSPACE GmbH"
 #define VER_PRODUCTNAME_STR         "V2gDecoder"
-#define VER_PRODUCTVERSION          1,4,0,0
-#define VER_PRODUCTVERSION_STR      "1.4.0.0\0"
+#define VER_PRODUCTVERSION          1,4,1,0
+#define VER_PRODUCTVERSION_STR      "1.4.1.0\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION VER_FILEVERSION

--- a/Wireshark/plugins/v2gcommon.lua
+++ b/Wireshark/plugins/v2gcommon.lua
@@ -28,6 +28,6 @@ end
 
 local v2gcommon = {}
 
-v2gcommon.DS_V2GSHARK_VERSION = "1.4.0" -- DO NOT CHANGE
+v2gcommon.DS_V2GSHARK_VERSION = "1.4.1" -- DO NOT CHANGE
 
 return v2gcommon

--- a/Wireshark/plugins/v2gllc.lua
+++ b/Wireshark/plugins/v2gllc.lua
@@ -6,9 +6,12 @@
 --
 -- See license file (dsV2Gshark_LICENSE.txt)
 --
+local HPAV_PACKET_SIZE = 60
+local HPAV_ETHERNET_TYPE = 0x88e1
+
 local v2gcommon = require("v2gcommon")
 
-p_hpav_llc = Proto("homeplug-av-llc", "HomePlug AV protocol LLC diagnostics")
+p_hpav_llc = Proto("homeplug-llc", "HomePlug AV protocol LLC diagnostics")
 local p_hpav_llc_info = {
     version = v2gcommon.DS_V2GSHARK_VERSION,
     author = "dSPACE GmbH",
@@ -115,22 +118,20 @@ local function cp_state_to_int(cp_state)
     return 0
 end
 
-function p_hpav_llc.dissector(buf, pinfo, root)
-    if buf:len() == 0 then
+local heuristic_hpav_dissector = function(buf, pinfo, root)
+    -- check size
+    if buf:len() ~= HPAV_PACKET_SIZE then
         return 0
     end
 
-    -- always call default homeplug-av dissector first
-    local hpav_dissector = Dissector.get("homeplug-av")
-    local consumed_bytes_hpav
-    if hpav_dissector ~= nil then
-        consumed_bytes_hpav = hpav_dissector:call(buf, pinfo, root)
-    else
-        -- some older wireshark versions does not have a homeplug-av dissector
-        consumed_bytes_hpav = Dissector.get("data"):call(buf, pinfo, root)
-        pinfo.cols.info = "Homeplug AV"
-    end
+    -- check eth type
+	if buf(12,2):uint() ~= HPAV_ETHERNET_TYPE then
+		return 0
+	end
 
+    buf = buf(14):tvb() -- skip eth header
+
+    -- check hpav message type
     local mac_mme_type = buf(1, 2):le_uint()
     local mme_vendor = buf(5, 3):uint()
     local freq, dutycycle, voltage, result
@@ -139,8 +140,15 @@ function p_hpav_llc.dissector(buf, pinfo, root)
     elseif mme_vendor == 0x0080E1 and mac_mme_type == 0xA22E then -- Vendor OUI: ST/IoTecha
         freq, dutycycle, voltage, result = extract_infos_iotecha(buf)
     else
-        -- default homeplug-av packet
-        return consumed_bytes_hpav
+        return 0
+    end
+
+    root:add("Ethernet II,", "dissection skipped for this packet! If you want to inspect this layer, please deactivate homeplug-llc")
+
+    -- call default hpav dissector to add additional information
+    local hpav_dissector = Dissector.get("homeplug-av")
+    if hpav_dissector ~= nil then
+        hpav_dissector:call(buf, pinfo, root)
     end
 
     pinfo.cols.protocol = "HomePlug AV LLC"
@@ -177,7 +185,8 @@ function p_hpav_llc.dissector(buf, pinfo, root)
     else
         pinfo.cols.info = "CP State: " .. cp_state
     end
-    return buf:len()
+    return HPAV_PACKET_SIZE
 end
 
-DissectorTable.get("ethertype"):add(0x88e1, p_hpav_llc)
+-- use heuristic dissection on ethernet layer to support older wireshark versions
+p_hpav_llc:register_heuristic("eth", heuristic_hpav_dissector)

--- a/Wireshark/plugins/v2gllc.lua
+++ b/Wireshark/plugins/v2gllc.lua
@@ -125,9 +125,9 @@ local heuristic_hpav_dissector = function(buf, pinfo, root)
     end
 
     -- check eth type
-	if buf(12,2):uint() ~= HPAV_ETHERNET_TYPE then
-		return 0
-	end
+    if buf(12, 2):uint() ~= HPAV_ETHERNET_TYPE then
+        return 0
+    end
 
     buf = buf(14):tvb() -- skip eth header
 
@@ -143,7 +143,10 @@ local heuristic_hpav_dissector = function(buf, pinfo, root)
         return 0
     end
 
-    root:add("Ethernet II,", "dissection skipped for this packet! If you want to inspect this layer, please deactivate homeplug-llc")
+    root:add(
+        "Ethernet II,",
+        "dissection skipped for this packet! If you want to inspect this layer, please deactivate homeplug-llc"
+    )
 
     -- call default hpav dissector to add additional information
     local hpav_dissector = Dissector.get("homeplug-av")


### PR DESCRIPTION
In some older wireshark versions, the default HomePlug AV dissector was completely overridden by our homeplug-av-llc dissector. To prevent this, we switched to a heuristic dissector.