### PR TITLE
Fix build error for Fedora 40

### DIFF
--- a/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_ACDP_Decoder.c
+++ b/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_ACDP_Decoder.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <ctype.h>
 
 #include "exi_basetypes.h"
 #include "exi_types_decoder.h"

--- a/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_WPT_Decoder.c
+++ b/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_WPT_Decoder.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <ctype.h>
 
 #include "exi_basetypes.h"
 #include "exi_types_decoder.h"


### PR DESCRIPTION
Fix erro:
```
...
[   25s] iso-20/iso20_ACDP_Decoder.c:109:37: error: implicit declaration of function ‘isprint’ [-Wimplicit-function-declaration]
[   25s]   109 |                                 if(!isprint(TransformType->Algorithm.characters[i]))
...
```

To remove implicit declaration of function ‘isprint’, add in the file:

```
```