### PR TITLE
Fix format specifiers and missing include

### DIFF
--- a/V2G_Libraries/Third_Party/cbv2g/din/din_msgDefDecoder.c
+++ b/V2G_Libraries/Third_Party/cbv2g/din/din_msgDefDecoder.c
@@ -18,6 +18,7 @@
   * @brief Description goes here
   *
   **/
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
 #include <ctype.h>
@@ -14723,7 +14724,7 @@ static int decode_din_MeterInfoType(exi_bitstream_t* stream, struct din_MeterInf
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", MeterInfoType->TMeter);
+                        sprintf(append, "%" PRIi64, MeterInfoType->TMeter);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->TMeter_isUsed = 1u;
@@ -14846,7 +14847,7 @@ static int decode_din_MeterInfoType(exi_bitstream_t* stream, struct din_MeterInf
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", MeterInfoType->TMeter);
+                        sprintf(append, "%" PRIi64, MeterInfoType->TMeter);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->TMeter_isUsed = 1u;
@@ -14921,7 +14922,7 @@ static int decode_din_MeterInfoType(exi_bitstream_t* stream, struct din_MeterInf
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", MeterInfoType->TMeter);
+                        sprintf(append, "%" PRIi64, MeterInfoType->TMeter);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->TMeter_isUsed = 1u;
@@ -14967,7 +14968,7 @@ static int decode_din_MeterInfoType(exi_bitstream_t* stream, struct din_MeterInf
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", MeterInfoType->TMeter);
+                        sprintf(append, "%" PRIi64, MeterInfoType->TMeter);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->TMeter_isUsed = 1u;
@@ -17718,7 +17719,7 @@ static int decode_din_SessionSetupResType(exi_bitstream_t* stream, struct din_Se
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", SessionSetupResType->DateTimeNow);
+                        sprintf(append, "%" PRIi64, SessionSetupResType->DateTimeNow);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         SessionSetupResType->DateTimeNow_isUsed = 1u;
@@ -19699,7 +19700,7 @@ static int decode_din_PaymentDetailsResType(exi_bitstream_t* stream, struct din_
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", PaymentDetailsResType->DateTimeNow);
+                        sprintf(append, "%" PRIi64, PaymentDetailsResType->DateTimeNow);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 3;

--- a/V2G_Libraries/Third_Party/cbv2g/iso-2/iso2_msgDefDecoder.c
+++ b/V2G_Libraries/Third_Party/cbv2g/iso-2/iso2_msgDefDecoder.c
@@ -18,6 +18,7 @@
   * @brief Description goes here
   *
   **/
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
 #include <ctype.h>
@@ -18414,7 +18415,7 @@ static int decode_iso2_MeterInfoType(exi_bitstream_t* stream, struct iso2_MeterI
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterReading);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterReading);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterReading_isUsed = 1u;
@@ -18517,7 +18518,7 @@ static int decode_iso2_MeterInfoType(exi_bitstream_t* stream, struct iso2_MeterI
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", MeterInfoType->TMeter);
+                        sprintf(append, "%" PRIi64, MeterInfoType->TMeter);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->TMeter_isUsed = 1u;
@@ -18640,7 +18641,7 @@ static int decode_iso2_MeterInfoType(exi_bitstream_t* stream, struct iso2_MeterI
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", MeterInfoType->TMeter);
+                        sprintf(append, "%" PRIi64, MeterInfoType->TMeter);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->TMeter_isUsed = 1u;
@@ -18715,7 +18716,7 @@ static int decode_iso2_MeterInfoType(exi_bitstream_t* stream, struct iso2_MeterI
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", MeterInfoType->TMeter);
+                        sprintf(append, "%" PRIi64, MeterInfoType->TMeter);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->TMeter_isUsed = 1u;
@@ -18761,7 +18762,7 @@ static int decode_iso2_MeterInfoType(exi_bitstream_t* stream, struct iso2_MeterI
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", MeterInfoType->TMeter);
+                        sprintf(append, "%" PRIi64, MeterInfoType->TMeter);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->TMeter_isUsed = 1u;
@@ -24647,7 +24648,7 @@ static int decode_iso2_PaymentDetailsResType(exi_bitstream_t* stream, struct iso
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", PaymentDetailsResType->EVSETimeStamp);
+                        sprintf(append, "%" PRIi64, PaymentDetailsResType->EVSETimeStamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 3;
@@ -26938,7 +26939,7 @@ static int decode_iso2_SessionSetupResType(exi_bitstream_t* stream, struct iso2_
                     if (error == 0)
                     {
                         char append[21]; // max length: 19 digits + 1 sign + 1 zero terminator
-                        sprintf(append, "%lld", SessionSetupResType->EVSETimeStamp);
+                        sprintf(append, "%" PRIi64, SessionSetupResType->EVSETimeStamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         SessionSetupResType->EVSETimeStamp_isUsed = 1u;

--- a/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_ACDP_Decoder.c
+++ b/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_ACDP_Decoder.c
@@ -18,6 +18,7 @@
   * @brief Description goes here
   *
   **/
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
@@ -6504,7 +6505,7 @@ static int decode_iso20_acdp_MessageHeaderType(exi_bitstream_t* stream, struct i
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MessageHeaderType->TimeStamp);
+                        sprintf(append, "%" PRIu64, MessageHeaderType->TimeStamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 69;

--- a/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_ACDP_Decoder.c
+++ b/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_ACDP_Decoder.c
@@ -18,6 +18,7 @@
   * @brief Description goes here
   *
   **/
+#include <ctype.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <string.h>

--- a/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_AC_Decoder.c
+++ b/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_AC_Decoder.c
@@ -18,6 +18,7 @@
   * @brief Description goes here
   *
   **/
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
 #include <ctype.h>
@@ -6758,7 +6759,7 @@ static int decode_iso20_ac_MessageHeaderType(exi_bitstream_t* stream, struct iso
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MessageHeaderType->TimeStamp);
+                        sprintf(append, "%" PRIu64, MessageHeaderType->TimeStamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 73;
@@ -13852,7 +13853,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->ChargedEnergyReadingWh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->ChargedEnergyReadingWh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 140;
@@ -13890,7 +13891,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_DischargedEnergyReadingWh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_DischargedEnergyReadingWh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_DischargedEnergyReadingWh_isUsed = 1u;
@@ -13916,7 +13917,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->CapacitiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->CapacitiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->CapacitiveEnergyReadingVARh_isUsed = 1u;
@@ -13942,7 +13943,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -14045,7 +14046,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -14091,7 +14092,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->CapacitiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->CapacitiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->CapacitiveEnergyReadingVARh_isUsed = 1u;
@@ -14117,7 +14118,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -14220,7 +14221,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -14266,7 +14267,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -14369,7 +14370,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -14492,7 +14493,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -14567,7 +14568,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -14613,7 +14614,7 @@ static int decode_iso20_ac_MeterInfoType(exi_bitstream_t* stream, struct iso20_a
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -14707,7 +14708,7 @@ static int decode_iso20_ac_ReceiptType(exi_bitstream_t* stream, struct iso20_ac_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", ReceiptType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, ReceiptType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 147;

--- a/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_CommonMessages_Decoder.c
+++ b/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_CommonMessages_Decoder.c
@@ -18,6 +18,7 @@
   * @brief Description goes here
   *
   **/
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
 #include <ctype.h>
@@ -7244,7 +7245,7 @@ static int decode_iso20_PowerScheduleType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", PowerScheduleType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, PowerScheduleType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 89;
@@ -8621,7 +8622,7 @@ static int decode_iso20_EVPowerScheduleType(exi_bitstream_t* stream, struct iso2
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", EVPowerScheduleType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, EVPowerScheduleType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 111;
@@ -9562,7 +9563,7 @@ static int decode_iso20_EVAbsolutePriceScheduleType(exi_bitstream_t* stream, str
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", EVAbsolutePriceScheduleType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, EVAbsolutePriceScheduleType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 120;
@@ -14855,7 +14856,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->ChargedEnergyReadingWh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->ChargedEnergyReadingWh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 198;
@@ -14893,7 +14894,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_DischargedEnergyReadingWh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_DischargedEnergyReadingWh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_DischargedEnergyReadingWh_isUsed = 1u;
@@ -14919,7 +14920,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->CapacitiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->CapacitiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->CapacitiveEnergyReadingVARh_isUsed = 1u;
@@ -14945,7 +14946,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -15048,7 +15049,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -15094,7 +15095,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->CapacitiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->CapacitiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->CapacitiveEnergyReadingVARh_isUsed = 1u;
@@ -15120,7 +15121,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -15223,7 +15224,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -15269,7 +15270,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -15372,7 +15373,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -15495,7 +15496,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -15570,7 +15571,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -15616,7 +15617,7 @@ static int decode_iso20_MeterInfoType(exi_bitstream_t* stream, struct iso20_Mete
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -16254,7 +16255,7 @@ static int decode_iso20_ReceiptType(exi_bitstream_t* stream, struct iso20_Receip
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", ReceiptType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, ReceiptType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 214;
@@ -18905,7 +18906,7 @@ static int decode_iso20_AbsolutePriceScheduleType(exi_bitstream_t* stream, struc
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", AbsolutePriceScheduleType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, AbsolutePriceScheduleType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 266;
@@ -18943,7 +18944,7 @@ static int decode_iso20_AbsolutePriceScheduleType(exi_bitstream_t* stream, struc
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", AbsolutePriceScheduleType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, AbsolutePriceScheduleType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 266;
@@ -20157,7 +20158,7 @@ static int decode_iso20_PriceLevelScheduleType(exi_bitstream_t* stream, struct i
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", PriceLevelScheduleType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, PriceLevelScheduleType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 283;
@@ -20195,7 +20196,7 @@ static int decode_iso20_PriceLevelScheduleType(exi_bitstream_t* stream, struct i
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", PriceLevelScheduleType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, PriceLevelScheduleType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 283;
@@ -21008,7 +21009,7 @@ static int decode_iso20_MessageHeaderType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MessageHeaderType->TimeStamp);
+                        sprintf(append, "%" PRIu64, MessageHeaderType->TimeStamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 295;
@@ -27477,7 +27478,7 @@ static int decode_iso20_EVPowerProfileType(exi_bitstream_t* stream, struct iso20
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", EVPowerProfileType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, EVPowerProfileType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 410;
@@ -36056,7 +36057,7 @@ static int decode_iso20_VehicleCheckOutReqType(exi_bitstream_t* stream, struct i
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", VehicleCheckOutReqType->CheckOutTime);
+                        sprintf(append, "%" PRIu64, VehicleCheckOutReqType->CheckOutTime);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 2;

--- a/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_DC_Decoder.c
+++ b/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_DC_Decoder.c
@@ -18,6 +18,7 @@
   * @brief Description goes here
   *
   **/
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
 #include <ctype.h>
@@ -6764,7 +6765,7 @@ static int decode_iso20_dc_MessageHeaderType(exi_bitstream_t* stream, struct iso
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MessageHeaderType->TimeStamp);
+                        sprintf(append, "%" PRIu64, MessageHeaderType->TimeStamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 73;
@@ -10475,7 +10476,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->ChargedEnergyReadingWh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->ChargedEnergyReadingWh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 105;
@@ -10513,7 +10514,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_DischargedEnergyReadingWh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_DischargedEnergyReadingWh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_DischargedEnergyReadingWh_isUsed = 1u;
@@ -10539,7 +10540,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->CapacitiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->CapacitiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->CapacitiveEnergyReadingVARh_isUsed = 1u;
@@ -10565,7 +10566,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -10668,7 +10669,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -10714,7 +10715,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->CapacitiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->CapacitiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->CapacitiveEnergyReadingVARh_isUsed = 1u;
@@ -10740,7 +10741,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -10843,7 +10844,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -10889,7 +10890,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -10992,7 +10993,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -11115,7 +11116,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -11190,7 +11191,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -11236,7 +11237,7 @@ static int decode_iso20_dc_MeterInfoType(exi_bitstream_t* stream, struct iso20_d
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -12544,7 +12545,7 @@ static int decode_iso20_dc_ReceiptType(exi_bitstream_t* stream, struct iso20_dc_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", ReceiptType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, ReceiptType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 131;

--- a/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_WPT_Decoder.c
+++ b/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_WPT_Decoder.c
@@ -18,6 +18,7 @@
   * @brief Description goes here
   *
   **/
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
@@ -9389,7 +9390,7 @@ static int decode_iso20_wpt_MessageHeaderType(exi_bitstream_t* stream, struct is
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MessageHeaderType->TimeStamp);
+                        sprintf(append, "%" PRIu64, MessageHeaderType->TimeStamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 109;
@@ -13842,7 +13843,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->ChargedEnergyReadingWh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->ChargedEnergyReadingWh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 143;
@@ -13880,7 +13881,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_DischargedEnergyReadingWh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_DischargedEnergyReadingWh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_DischargedEnergyReadingWh_isUsed = 1u;
@@ -13906,7 +13907,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->CapacitiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->CapacitiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->CapacitiveEnergyReadingVARh_isUsed = 1u;
@@ -13932,7 +13933,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -14035,7 +14036,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -14081,7 +14082,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->CapacitiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->CapacitiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->CapacitiveEnergyReadingVARh_isUsed = 1u;
@@ -14107,7 +14108,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -14210,7 +14211,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -14256,7 +14257,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->BPT_InductiveEnergyReadingVARh);
+                        sprintf(append, "%" PRIu64, MeterInfoType->BPT_InductiveEnergyReadingVARh);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->BPT_InductiveEnergyReadingVARh_isUsed = 1u;
@@ -14359,7 +14360,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -14482,7 +14483,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -14557,7 +14558,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -14603,7 +14604,7 @@ static int decode_iso20_wpt_MeterInfoType(exi_bitstream_t* stream, struct iso20_
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", MeterInfoType->MeterTimestamp);
+                        sprintf(append, "%" PRIu64, MeterInfoType->MeterTimestamp);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         MeterInfoType->MeterTimestamp_isUsed = 1u;
@@ -15947,7 +15948,7 @@ static int decode_iso20_wpt_ReceiptType(exi_bitstream_t* stream, struct iso20_wp
                     if (error == 0)
                     {
                         char append[20]; // max length: 19 digits + 0 sign + 1 zero terminator
-                        sprintf(append, "%llu", ReceiptType->TimeAnchor);
+                        sprintf(append, "%" PRIu64, ReceiptType->TimeAnchor);
                         strcat(xmlOut, ">");
                         strcat(xmlOut, append);
                         grammar_id = 168;

--- a/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_WPT_Decoder.c
+++ b/V2G_Libraries/Third_Party/cbv2g/iso-20/iso20_WPT_Decoder.c
@@ -18,6 +18,7 @@
   * @brief Description goes here
   *
   **/
+#include <ctype.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
This provides two fixes for building on Fedora with gcc 14:

- The format specifiers threw tons of warnings. They are exchanged with the corresponding `PRI*` macros. This assumes the availability of inttypes.h (C99).
- `isprint()` was missing its appropiate include.

These changes build fine in the `build-windows` and `build-linux` workflows.