### PR TITLE
Add instructions for building on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Click on a packet in the graph to inspect it in the Wireshark main window. Press
 - Operating Sytems:
     - Windows 7 or higher
     - Linux x64 (see [Limitations](#limitations))
-    - Mac OS currently not supported
+    - macOS (tested on Apple Silicon and macOS Sequoia 15.6)
 
 ## Installation notes
 - The installer can be downloaded from [GitHub Releases](https://github.com/dspace-group/dsV2Gshark/releases/latest). The setup is signed by "dSPACE GmbH".
@@ -66,6 +66,16 @@ Click on a packet in the graph to inspect it in the Wireshark main window. Press
 - Installation size is about 13 MB
 - Supports normal and portable version of Wireshark
 - Optionally, a Wireshark Profile will be added which handles the filter buttons, color filters and I/O Graph. This profile is automatically activated after installation. You can change the current profile in the bottom right corner (shortcut: Ctrl + Shift + A).
+
+### macOS
+
+You need to have gnutls installed via brew for the plugin to compile:
+
+```brew install gnutls```
+
+Build the v2g library by running `V2G_Libraries/build_macos.sh`, then copy:
+- `V2G_Libraries/v2gLib/bin/v2gLib.so` to `~/.local/lib/wireshark`
+- `Wireshark/plugins/*` to `~/.local/lib/wireshark/plugins`
 
 
 ## Limitations

--- a/V2G_Libraries/build_macos.sh
+++ b/V2G_Libraries/build_macos.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# build default lib
+export IFLAGS_LUA=-I"../Third_Party/lua/lua-52/include" # 53 and 54 are compatible with 52
+export BINARY_OUT_NAME=v2gLib.so
+make -C v2gLib -f makefile_macos all
+if [ $? -ne 0 ]; then
+    echo "failed to build v2gLib!"
+    exit 1
+fi
+
+echo "Lua libs built successfully!"

--- a/V2G_Libraries/v2gLib/makefile_macos
+++ b/V2G_Libraries/v2gLib/makefile_macos
@@ -1,0 +1,58 @@
+CC = g++
+MKDIR = mkdir -p
+RM = rm -rf
+
+
+
+IFLAGS_LUA ?= -I"../Third_Party/lua/lua-54/include"
+BINARY_OUT_NAME ?= v2gLib.so
+
+SRC_DIR = src
+OBJ_DIR = obj
+
+SOURCE = $(wildcard $(SRC_DIR)/*.cpp)
+HEADER = $(wildcard $(SRC_DIR)/*.h)
+OBJECTS = $(patsubst %.cpp,$(OBJ_DIR)/%.o,$(SOURCE))
+DEPS = $(patsubst %.h,$(OBJ_DIR)/%.d,$(HEADER))
+
+BINARY_DIR_OUT = bin
+BINARY_OUT = $(BINARY_DIR_OUT)/$(BINARY_OUT_NAME)
+
+FLAGS_COMMON = -Wall -O3 -MP -MD -fPIC
+FLAGS_LIB = -shared -L/opt/homebrew/lib -lgnutls -lz -llua -lxml2
+
+IFLAGS = $(IFLAGS_LUA) -I"../Third_Party/zlib/include" -I"../Third_Party/libxml2/include/libxml2" -I"../Third_Party/GnuTLS/include"
+
+# CBV2G
+PATH_CBV2G = ../Third_Party/cbv2g
+OBJECTS_CBV2G = $(wildcard $(PATH_CBV2G)/$(OBJ_DIR)/*/*.o)
+INCLUDES_CBV2G = $(wildcard $(PATH_CBV2G)/*/.)
+IFLAGS_CBV2G = $(foreach d, $(INCLUDES_CBV2G), -I"$(d)")
+
+all: $(BINARY_OUT)
+
+$(BINARY_OUT): prepare_dirs cbv2g $(OBJECTS)
+	$(CC) $(FLAGS_COMMON) $(FLAGS_LIB) $(OBJECTS) $(OBJECTS_CBV2G) -o $(BINARY_OUT) $(IFLAGS)
+
+$(OBJ_DIR)/%.o: %.cpp
+	$(MKDIR) $(dir $@)
+	$(CC) -c $(FLAGS_COMMON) $< -o $@ $(IFLAGS) $(IFLAGS_CBV2G)
+	
+	
+	
+
+cbv2g:
+	make -C $(PATH_CBV2G) build
+
+prepare_dirs:
+	$(MKDIR) $(BINARY_DIR_OUT)
+
+clean: clean-obj
+	$(RM) $(BINARY_DIR_OUT)
+	make -C $(PATH_CBV2G) clean
+
+clean-obj:
+	$(RM) $(OBJ_DIR) res.o
+
+.PHONY: $(BINARY_OUT) resource cbv2g prepare_dirs clean
+-include $(DEPS)


### PR DESCRIPTION
I noticed that the README said that macOS isn't supported, but I was able to make it compile with some minor changes. 

I'm not 100% on exactly which dependencies are required to compile it, but the only thing that stopped me was that I didn't have the arm64 version of GnuTLS installed. Fixing my brew setup, and giving some pointers to where brew keeps the libraries in the makefile seemed to make everything work.

Sending this PR if it helps anyone else.
Seems like a helpful plugin so far, thanks for providing it!