### PR TITLE
Add "ISO15118" description to "CP state" if PWM is ~5%

### DIFF
--- a/Wireshark/plugins/v2ghpscs.lua
+++ b/Wireshark/plugins/v2ghpscs.lua
@@ -211,11 +211,11 @@ local function dissect_cp_state_ind(buf, pinfo, root, freq, dutycycle, voltage, 
         subtree:add(f_acmax, ac_max_current):append_text("A")
         pinfo.cols.info = "CP State: " .. cp_state .. " [AC max current: " .. ac_max_current .. "A]"
     else
-        local cp_iso = ""
+        local cp_info = ""
         if dutycycle > 4 and dutycycle < 6 then
-            cp_iso = " [" .. dutycycle .. "% - ISO15118]"
+            cp_info = " [HLC]"
         end
-        pinfo.cols.info = "CP State: " .. cp_state .. cp_iso
+        pinfo.cols.info = "CP State: " .. cp_state .. cp_info
     end
     pinfo.cols.protocol = "HomePlug AV (Ext)"
     return buf:len()


### PR DESCRIPTION
The "CP state" already shows very nice additional information about the allowed AC current, depending on the PWM ratio. But it does so far not show anything if PWM is at 5%.
This patch adds some short informative text ("[5% - ISO15118]") to the "CP state" line in the Wireshark main view.